### PR TITLE
Take into account semantical 'errors' key in JSON body

### DIFF
--- a/lib/shopify_api/message_enricher.rb
+++ b/lib/shopify_api/message_enricher.rb
@@ -6,7 +6,13 @@ class ShopifyAPI::MessageEnricher < SimpleDelegator
 
     @_cached_message ||= begin
       detailed_error = begin
-        JSON.parse(body)['error'].to_s
+        parsed_body = JSON.parse(body)
+
+        if parsed_body['error']
+          parsed_body['error'].to_s
+        elsif parsed_body['errors']
+          Array(parsed_body['errors']).join('; ')
+        end
       rescue JSON::ParserError
         nil
       end

--- a/test/message_enricher_test.rb
+++ b/test/message_enricher_test.rb
@@ -2,10 +2,22 @@ require 'test_helper'
 
 class MessageEnricherTest < Test::Unit::TestCase
 
-  def test_enriches_initial_message_when_body_is_passed
+  def test_enriches_initial_message_when_body_contains_error
     response = enriched_response(422, 'InitialMessage', { error: 'My Error' })
 
     assert_equal 'InitialMessage (My Error)', response.message
+  end
+
+  def test_enriches_initial_message_when_body_contains_errors_array
+    response = enriched_response(422, 'InitialMessage', { errors: ['My Error1', 'My Error2'] })
+
+    assert_equal 'InitialMessage (My Error1; My Error2)', response.message
+  end
+
+  def test_enriches_initial_message_when_body_contains_errors_single_value
+    response = enriched_response(422, 'InitialMessage', { errors: 'My Error1' })
+
+    assert_equal 'InitialMessage (My Error1)', response.message
   end
 
   def test_returns_initial_message_when_code_is_200


### PR DESCRIPTION
According to the documentation
https://help.shopify.com/en/api/getting-started/response-status-codes:
  422 Unprocessable Entity
  The request body was well-formed but contains semantical errors.
  The response body will provide more details in the errors or
  error parameters.

There might be `errors` key containing array of error messages. This is
handled in the pull-request